### PR TITLE
fix broken link in docs

### DIFF
--- a/packages/docs/content/designing-state.mdx
+++ b/packages/docs/content/designing-state.mdx
@@ -47,4 +47,4 @@ Like other state management libraries, State Designer provides a reliable, flexi
 
 You'll find its API and feature set tuned specifically to design concerns. If you've struggled with making decisions about state in the past, then you might like what you find.
 
-If you'd like to learn more, you can start learning State Designer right away by reading the [guide](/docs/learn/intro). Check out some examples to see what finished projects look like—or kick off a new project with a template.
+If you'd like to learn more, you can start learning State Designer right away by reading the [guide](/). Check out some examples to see what finished projects look like—or kick off a new project with a template.


### PR DESCRIPTION
Hey @steveruizok, thanks for building State Designer! Great stuff, I'm a big fan your work. 

I was reading the docs and found a broken link at the bottom of https://state-designer.com/designing-state 

I did a little digging and _think_ that you want `reading the [guide](/docs/learn/intro)` to navigate to `reading the [guide](/)`.

Happy to adjust if you'd like!

